### PR TITLE
Add package-deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,9 @@ A hyperclick provider for Vue components that lets you jump to where variables a
 
 Supports jumping between all combinations of `*.vue` and `*.js` files
 
-## dependencies
-- `js-hyperclick` plugin has to be installed to provide core js hyperclick capabilities
-- `language-vue` plugin is required to detect `*.vue` grammar correctly
-
 ## installation
 
 Install via atom or apm:
 ```
-apm install vue-hyperclick js-hyperclick hyperclick language-vue
+apm install vue-hyperclick
 ```

--- a/package.json
+++ b/package.json
@@ -24,5 +24,6 @@
   },
   "devDependencies": {
     "eslint": "^3.7.0"
-  }
+  },
+  "package-deps": ["language-vue", "js-hyperclick"]
 }


### PR DESCRIPTION
This PR adds `package-deps` in `package.json` so that user will no longer need to install other packages himself. Now he should get a nice built-in atom's prompt that this plugin requires certain dependencies, like for example here: 
![image](https://user-images.githubusercontent.com/4093559/27664798-e218ef48-5c69-11e7-8cc2-e9b63a49961b.png)

Because of that I also removed dependencies part from Readme, as it's no longer necessary.